### PR TITLE
No multiline strings in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,10 @@ from setuptools import find_packages
 setup(
     name='obs_generator',
     version = '1.0',
-    description='Combine seed image and dark ramp into simulated ramp'
-    long_description=('A tool to combine a noiseless seed image with a '
-                      'dark current ramp in order to produce a simulated'
-                      ' NIRCam integration/exposure with realistic '
-                      'detector artifacts.'),
-    author='Bryan Hilbert',
-    author_email='hilbert@stsci.edu',
+    description = 'Combine seed image and dark ramp into simulated ramp'
+    long_description = 'A tool to combine a noiseless seed image with a dark current ramp in order to produce a simulated NIRCam integration/exposure with realistic detector artifacts.',
+    author = 'Bryan Hilbert',
+    author_email = 'hilbert@stsci.edu',
     keywords = ['astronomy'],
     classifiers = ['Programming Language :: Python'],
     packages = find_packages(exclude=["examples"]),


### PR DESCRIPTION
setup.py fails with a multi-line string, so I brought the long description back to a single line.