### PR TITLE
Added scripts for cropping and blotting 

### DIFF
--- a/obs_generator/scripts/apt_inputs.py
+++ b/obs_generator/scripts/apt_inputs.py
@@ -47,8 +47,8 @@ from astropy.table import Table, Column
 from astropy.io import ascii
 import numpy as np
 import yaml
-import rotations
-import set_telescope_pointing_separated as set_telescope_pointing
+from . import rotations
+from . import set_telescope_pointing_separated as set_telescope_pointing
 
 class AptInput:
     def __init__(self):
@@ -731,7 +731,8 @@ class AptInput:
     
         #loop over entries in dict and duplicate by the
         #number of dither positions  
-        keys = np.array(indict.keys())
+        #keys = np.array(indict.keys())
+        keys = indict.keys()
         for i in range(len(indict['PrimaryDithers'])):
             #entry = np.array([item[i] for item in dict.values()])
             arr = np.array([item[i] for item in indict.values()])

--- a/obs_generator/scripts/blot_image.py
+++ b/obs_generator/scripts/blot_image.py
@@ -1,0 +1,240 @@
+#! /usr/bin/env python
+
+'''
+Blot an image back to some input WCSs.
+
+Use in conjunction with crop_mosaic.py
+'''
+import sys, os
+from copy import copy
+import glob
+from astropy.io import fits
+from jwst import datamodels
+import gwcs
+from jwst.outlier_detection import outlier_detection
+from jwst.assign_wcs import AssignWcsStep
+from jwst.datamodels import container
+import set_telescope_pointing_separated as stp
+
+
+class Blot():
+
+    def __init__(self):
+        self.detector = ['']
+        self.center_ra = [0.]
+        self.center_dec = [0.]
+        self.pav3 = [0.]
+        self.outfile = None
+
+        distdir = '/ifs/jwst/wit/witserv/data4/nrc/hilbert/distortion_reference_file/jwreftools/nircam/'
+        self.distfiles = glob.glob(os.path.join(distdir,'NRC*FULL_distortion.asdf'))
+
+        # Pixel scales for the NIRCam detectors
+        self.nrc_scale = {'A1':(0.0311,0.0313),
+                     'A2':(0.0308,0.0309),
+                     'A3':(0.0313,0.0315),
+                     'A4':(0.0309,0.0309),
+                     'A5':(0.0628,0.0631),
+                     'B1':(0.0307,0.0308),
+                     'B2':(0.0311,0.0313),
+                     'B3':(0.0308,0.0309),
+                     'B4':(0.0313,0.0314),
+                     'B5':(0.0629,0.0632)}
+
+        self.v2refs = {'A1':120.671376,
+                       'A2':120.112090,
+                       'A3':51.934455,
+                       'A4':52.276773,
+                       'A5':86.103458,
+                       'B1':-120.968203,
+                       'B2':-121.144349,
+                       'B3':-53.123823,
+                       'B4':-52.818167,
+                       'B5':-89.389195}
+
+        self.v3refs = {'A1':-527.387665,
+                       'A2':-459.680558,
+                       'A3':-527.803414,
+                       'A4':-459.809697,
+                       'A5':-493.227512,
+                       'B1':-457.752680,
+                       'B2':-525.458174,
+                       'B3':-457.780381,
+                       'B4':-525.727255,
+                       'B5':-491.443963}
+
+        self.v3yangles = {'A1':-0.573843,
+                          'A2':-0.212057,
+                          'A3':0.185477,
+                          'A4':0.057459,
+                          'A5':-0.089504,
+                          'B1':0.375008,
+                          'B2':0.830079,
+                          'B3':-0.485114,
+                          'B4':-0.344918,
+                          'B5':-0.008844}
+
+    def blot(self):
+        
+        # Make sure detector, ra, dec, and roll have same number
+        # of elements
+        if ((len(self.detector) != len(self.center_ra)) | \
+                (len(self.detector) != len(self.center_dec)) | \
+                (len(self.detector) != len(self.pav3))):
+            print('WARNING: detector, center_ra, center_dec')
+            print('and pav3 all must have the same number')
+            print('of elements.')
+            sys.exit()
+
+        if type(self.blotfile) == str:
+            input_mod = datamodels.ImageModel(self.blotfile)
+            outbase = self.blotfile
+            
+            # Create a GWCS object from the input file's header
+            #input_header = fits.getheader(self.blotfile)
+            #transform = gwcs.utils.make_fitswcs_transform(header)
+            #input_mod.meta.wcs = gwcs.WCS(transform)
+
+        elif type(self.blotfile) == datamodels.image.ImageModel:
+            # Not a great solution at the moment. Save
+            # imagemodel instance so that you have a fits
+            # file from which the header can be retrieved
+            input_mod = copy(self.blotfile)
+            self.blotfile.save('temp.fits')
+            self.blotfile = 'temp.fits'
+            outbase = 'mosaic'
+            
+        else:
+            print('WARNING: unrecognized type for blotfile')
+            sys.exit()
+
+        # Create a GWCS object from the input file's header
+        input_header = fits.getheader(self.blotfile,ext=1)
+        transform = gwcs.utils.make_fitswcs_transform(input_header)
+        input_mod.meta.wcs = gwcs.WCS(forward_transform=transform,output_frame='world')
+        # Filter and pupil information
+        filter = input_mod.meta.instrument.filter
+        try:
+            pupil = input_mod.meta.instrument.pupil
+        except:
+            pupil = 'CLEAR'
+
+        # get position angle of input data
+        input_pav3 = input_mod.meta.wcsinfo.roll_ref
+
+        # parity is always -1 for nircam
+        parity = -1
+
+        blist = []
+        for (det,ra,dec,roll) in \
+            zip(self.detector,self.center_ra,\
+                self.center_dec,self.pav3):
+            # get detector-specific info 
+            v2ref,v3ref,v3ang = self.get_siaf_info(det)
+
+            # create datamodel with appropriate metadata
+            bmodel = self.make_model(det,ra,dec,v2ref,v3ref,v3ang,parity,input_pav3,filter,pupil)
+            shellname = 'wcs_model_to_blot_to_{}_{}_{}_{}.fits'.format(det,ra,dec,roll)
+            bmodel.save(shellname,overwrite=True)
+
+            tmpname = 'wcs_model_to_blot_to_BASEMODEL_{}_{}_{}_{}.fits'.format(det,ra,dec,roll)
+            bmodel.save(tmpname,overwrite=True)
+            
+            # use set_telescope_pointing to compute local roll
+            # angle and PC matrix
+            stp.add_wcs(shellname,roll=roll)
+
+            bmodel = datamodels.open(shellname)
+
+            # Now we need to run assign_wcs step so that these
+            # files get a gwcs object attached to them.
+            dist_reffile = [s for s in self.distfiles if det in s][0]
+            bmodel = AssignWcsStep.call(bmodel,override_distortion=dist_reffile)
+
+            tmpname = 'wcs_model_to_blot_to_ASSIGNWCS_{}_{}_{}_{}.fits'.format(det,ra,dec,roll)
+            bmodel.save(tmpname,overwrite=True)
+
+            # Add to the list of data model instances to blot to
+            blist.append(bmodel)
+            
+        #place the model instances to blot to in a ModelContainer
+        blot_list = container.ModelContainer(blist)
+        
+        #blot the image to each of the WCSs in the blot_list
+        pars = {'sinscl':1.0, 'interp':'poly5'}
+        reffiles = {}
+        mm = outlier_detection.OutlierDetection(blot_list,reffiles=reffiles,**pars)
+        blotted_datamodels = outlier_detection.blot_median(input_mod,blot_list,**mm.outlierpars)
+
+        for (bltted,det,ra,dec,roll) in \
+            zip(blotted_datamodels,self.detector,self.center_ra,\
+                self.center_dec,self.pav3):
+            outname = 'blotted_from_{}_to_{}_{}_{}_{}.fits'.format(outbase,det,ra,dec,roll)
+            bltted.save(outname)
+
+
+    def get_siaf_info(self,detname):
+        # get v2,v3 reference values and y3yangle for a given detector
+        vv = self.v2refs[detname]
+        vvv = self.v3refs[detname]
+        ang = self.v3yangles[detname]
+        return vv,vvv,ang
+
+
+    def make_model(self,detname,raval,decval,v2,v3,v3angle,vpar,rollval,filt,pup):
+        #define the WCS of the blotted output
+        blot_to = datamodels.ImageModel((2048,2048))
+        blot_to.meta.wcsinfo.cdelt1 = self.nrc_scale[detname][0] / 3600.
+        blot_to.meta.wcsinfo.cdelt2 = self.nrc_scale[detname][1] / 3600.
+        blot_to.meta.wcsinfo.crpix1 = 1024.5
+        blot_to.meta.wcsinfo.crpix2 = 1024.5
+        blot_to.meta.wcsinfo.crval1 = raval
+        blot_to.meta.wcsinfo.crval2 = decval
+        blot_to.meta.wcsinfo.ctype1 = 'RA---TAN'
+        blot_to.meta.wcsinfo.ctype2 = 'DEC--TAN'
+        blot_to.meta.wcsinfo.cunit1 = 'deg'
+        blot_to.meta.wcsinfo.cunit2 = 'deg'
+        blot_to.meta.wcsinfo.ra_ref = raval
+        blot_to.meta.wcsinfo.dec_ref = decval
+        blot_to.meta.wcsinfo.roll_ref = rollval 
+        blot_to.meta.wcsinfo.wcsaxes = 2
+        blot_to.meta.wcsinfo.v2_ref = v2
+        blot_to.meta.wcsinfo.v3_ref = v3
+        blot_to.meta.wcsinfo.v3yangle = v3angle
+        blot_to.meta.wcsinfo.vparity = vpar
+        blot_to.meta.instrument.channel = 'SHORT'
+        blot_to.meta.instrument.detector = 'NRC'+detname
+        blot_to.meta.instrument.filter = filt
+        blot_to.meta.instrument.module = detname[0]
+        blot_to.meta.instrument.name = 'NIRCAM'
+        blot_to.meta.instrument.pupil = pup
+        blot_to.meta.telescope = 'JWST'
+        blot_to.meta.exposure.start_time = 57410.24546415885
+        blot_to.meta.exposure.end_time = 57410.2477009838
+        blot_to.meta.exposure.type = 'NRC_IMAGE'
+        blot_to.meta.target.ra = raval
+        blot_to.meta.target.dec = decval
+        return blot_to
+
+
+    def add_options(self,parser=None,usage=None):
+        if parser is None:
+            parser = argparse.ArgumentParser(usage=usage,description='Extract SCA-sized area from moasic')
+        parser.add_argument("blotfile",help="Filename or model instance name of fits file containing mosaic.")
+        #parser.add_argument("--blotmodel",help="Datamodel containing array to blot",default=None)
+        parser.add_argument("--detector",help="NIRCam detectors to blot to. Multiple inputs ok. (e.g. A1 A5)",nargs='*') 
+        parser.add_argument("center_ra",help="RA at the center of the extracted area",type=np.float,nargs='*')
+        parser.add_argument("center_dec",help="Dec at the center of the extracted area",type=np.float,nargs='*')
+        parser.add_argument("pav3",help="Position angle for outputs to use when blotting",nargs='*')
+        parser.add_argument("--outfile",help="Name of output fits file containing extracted image",default=None,nargs='*')
+        return parser
+
+
+if __name__ == '__main__':
+    usagestring = 'USAGE: blot_image.py filename.fits --detector A1 A1 --center_ra 10.2 10.2001 --center_dec 12.9 12.91 --local_roll 0 0'
+
+    b = Blot()
+    parser = b.add_options(usage = usagestring)
+    args = parser.parse_args(namespace=b)
+    b.blot()
+

--- a/obs_generator/scripts/crop_and_blot.py
+++ b/obs_generator/scripts/crop_and_blot.py
@@ -1,0 +1,26 @@
+#! /usr/bin/env python
+
+'''
+test to combine crop_mosaic.py and blot_image.py
+'''
+
+import crop_mosaic
+import blot_image
+
+crop = crop_mosaic.Extraction()
+crop.mosaicfile = 'goodss_candels_udf_wfc3_f105w_010mas_test_drz.fits'
+crop.center_ra = 53.122751
+crop.center_dec = -27.805089
+crop.channel = 'short'
+crop.extract()
+
+#crop.cropped now has the datamodel with the mosaic piece...
+
+blot = blot_image.Blot()
+blot.blotfile = crop.cropped
+blot.detector = ['A1','A1']
+blot.center_ra = [53.122751,53.122751]
+blot.center_dec = [-27.805089,-27.805089]
+blot.pav3 = [0.,12.]
+blot.blot()
+

--- a/obs_generator/scripts/crop_mosaic.py
+++ b/obs_generator/scripts/crop_mosaic.py
@@ -1,0 +1,186 @@
+#! /usr/bin/env python
+
+'''
+Extract a roughly SCA-sized area from a distortion-free mosaic.
+This extracted area can then be blotted to match NIRCam distorion
+and then used as an input to the ramp simulator.
+'''
+
+from astropy.io import fits
+import argparse
+import numpy as np
+
+class Extraction():
+
+    def __init__(self):
+        self.mosaicfile = ''
+        self.center_ra = 0.0
+        self.center_dec = 0.0
+        self.channel = 'short'
+        self.outfile = None
+        self.nrc_scale = {'short':0.031,
+                          'long':0.063}
+
+
+    def extract(self):
+        # get WCS info from mosaic file
+        mosaic = fits.open(self.mosaicfile)
+        mosaic_ra_ref = mosaic[0].header['CRVAL1']
+        mosaic_dec_ref = mosaic[0].header['CRVAL2']
+        mosaic_x_ref = mosaic[0].header['CRPIX1']
+        mosaic_y_ref = mosaic[0].header['CRPIX2']
+        self.mosaic_x_type = mosaic[0].header['CTYPE1']
+        self.mosaic_y_type = mosaic[0].header['CTYPE2']
+        self.mosaic_scale_x = mosaic[0].header['CDELT1']*3600. #arcsec/pix
+        self.mosaic_scale_y = mosaic[0].header['CDELT2']*3600. #arcsec/pix
+        #self.mosaic_roll = 0. #North up
+        self.cd11 = mosaic[0].header['CD1_1']
+        self.cd12 = mosaic[0].header['CD1_2']
+        self.cd21 = mosaic[0].header['CD2_1']
+        self.cd22 = mosaic[0].header['CD2_2']
+        self.mosaic_roll = np.arccos(self.cd11/(self.mosaic_scale_x/3600.))
+
+        # define size of region to extract
+        outscale_x = self.nrc_scale[self.channel.lower()]
+        
+        # This assumes full frame!!! Need some buffer to account for distortion
+        nominal_size = 2897. + 300. #300 pixel buffer
+        self.nx = np.absolute(np.int(nominal_size * outscale_x / self.mosaic_scale_x))
+        self.ny = np.absolute(np.int(nominal_size * outscale_x / self.mosaic_scale_y))
+
+        # Need to calculate what pixel in the mosaic corresponds to the
+        # RA, Dec of the center of the cutout (center_ra,center_dec)
+        # For the moment, assume mosaic is north up, which Anton's are...
+        delta_ra = mosaic_ra_ref - self.center_ra
+        delta_dec = mosaic_dec_ref - self.center_dec
+
+        delta_x = delta_ra * self.mosaic_scale_x
+        delta_y = delta_dec * self.mosaic_scale_y
+        
+        centerx = mosaic_x_ref + delta_x
+        centery = mosaic_y_ref + delta_y
+
+        intcenterx = np.int(centerx)
+        intcentery = np.int(centery)
+
+        # extract the SCA-sized area from the moasic
+        ny_over_2 = np.int(self.ny / 2)
+        nx_over_2 = np.int(self.nx / 2)
+        print("Coords of center of cropped area",intcenterx,intcentery)
+        print("X-min, Y-max coords:",intcenterx-nx_over_2,intcenterx+nx_over_2)
+        print("Y-min, Y-max coords:",intcentery-ny_over_2,intcentery+ny_over_2)
+        
+        crop = mosaic[0].data[intcentery-ny_over_2:intcentery+ny_over_2,intcenterx-nx_over_2:intcenterx+nx_over_2]
+
+        # save extracted area - tests show saving with fits is much much
+        # faster than saving with a datamodel. So save with fits, and then
+        # place into a datamodel to prepare for later blotting
+        #self.saveDMS(crop,self.outfile)
+
+        # Place into a data model to prepare for blotting
+        self.cropped = self.populate_datamodel(crop)
+        
+        # Save only if outfile is not None
+        if self.outfile is not None:
+            #self.outfile = 'cropped_from_'+self.mosaicfile+'_ra_'+str(self.center_ra)+'_dec_'+str(self.center_dec)+'.fits'
+            self.savefits(crop,self.outfile)
+            print("Extracted image saved to {}".format(self.outfile))
+
+
+
+
+    def savefits(self,array,ofile):
+        h0 = fits.PrimaryHDU()
+        h1 = fits.ImageHDU()
+        h1.data = array
+
+        h1.header['CDELT1'] = self.mosaic_scale_x / 3600.
+        h1.header['CDELT2'] = self.mosaic_scale_y / 3600.
+        h1.header['CRPIX1'] = self.nx / 2 + 0.5
+        h1.header['CRPIX2'] = self.ny / 2 + 0.5
+        h1.header['CRVAL1'] = self.center_ra
+        h1.header['CRVAL2'] = self.center_dec
+        h1.header['CTYPE1'] = self.mosaic_x_type
+        h1.header['CTYPE2'] = self.mosaic_y_type
+        h1.header['CUNIT1'] = 'deg'
+        h1.header['CUNIT2'] = 'deg'
+        h1.header['RA_REF'] = self.center_ra
+        h1.header['DEC_REF'] = self.center_dec
+        h1.header['ROLL_REF'] = self.mosaic_roll * 180./np.pi
+        h1.header['WCSAXES'] = 2
+        h1.header['EXTNAME'] = 'SCI    '
+        h1.header['EXTVER'] = 1
+        # These assume north up orientation
+        #h0.header['PC1_1'] = self.mosaic_scale_x / 3600.
+        #h0.header['PC1_2'] = 0.
+        #h0.header['PC2_1'] = 0.
+        #h0.header['PC2_2'] = self.mosaic_scale_y / 3600.
+
+        h1.header['PC1_1'] = self.cd11 / (self.mosaic_scale_x/3600.)
+        h1.header['PC1_2'] = self.cd12 / (self.mosaic_scale_x/3600.)
+        h1.header['PC2_1'] = self.cd21 / (self.mosaic_scale_y/3600.)
+        h1.header['PC2_2'] = self.cd22 / (self.mosaic_scale_y/3600.)
+
+        #for key in h1.header:
+        #    print(key,h1.header[key])
+
+        hlist = fits.HDUList([h0,h1])
+        hlist.writeto(ofile,overwrite=True)
+
+
+    def populate_datamodel(self,array):
+        from jwst import datamodels
+
+        # now we need to update the WCS of the mosaic piece
+        cropped = datamodels.ImageModel()
+        cropped.meta.wcsinfo.cdelt1 = self.mosaic_scale_x / 3600.
+        cropped.meta.wcsinfo.cdelt2 = self.mosaic_scale_y / 3600.
+        cropped.meta.wcsinfo.crpix1 = self.nx / 2 + 0.5
+        cropped.meta.wcsinfo.crpix2 = self.ny / 2 + 0.5
+        cropped.meta.wcsinfo.crval1 = self.center_ra
+        cropped.meta.wcsinfo.crval2 = self.center_dec
+        cropped.meta.wcsinfo.ctype1 = self.mosaic_x_type
+        cropped.meta.wcsinfo.ctype2 = self.mosaic_y_type
+        cropped.meta.wcsinfo.cunit1 = 'deg'
+        cropped.meta.wcsinfo.cunit2 = 'deg'
+        cropped.meta.wcsinfo.ra_ref = self.center_ra
+        cropped.meta.wcsinfo.dec_ref = self.center_dec
+        cropped.meta.wcsinfo.roll_ref = self.mosaic_roll * 180./np.pi
+        cropped.meta.wcsinfo.wcsaxes = 2
+
+        # These assume north up orientation
+        #cropped.meta.wcsinfo.pc1_1 = self.mosaic_scale_x / 3600.
+        #cropped.meta.wcsinfo.pc1_2 = 0.
+        #cropped.meta.wcsinfo.pc2_1 = 0.
+        #cropped.meta.wcsinfo.pc2_2 = self.mosaic_scale_y / 3600.
+
+        cropped.meta.wcsinfo.pc1_1 = self.cd11 / (self.mosaic_scale_x/3600.)
+        cropped.meta.wcsinfo.pc1_2 = self.cd12 / (self.mosaic_scale_x/3600.)
+        cropped.meta.wcsinfo.pc2_1 = self.cd21 / (self.mosaic_scale_y/3600.)
+        cropped.meta.wcsinfo.pc2_2 = self.cd22 / (self.mosaic_scale_y/3600.)
+
+        cropped.data = array
+
+        #save the cropped view
+        #cropped.save(ofile)
+        return cropped
+
+
+    def add_options(self,parser=None,usage=None):
+        if parser is None:
+            parser = argparse.ArgumentParser(usage=usage,description='Extract SCA-sized area from moasic')
+        parser.add_argument("mosaicfile",help="Filename of fits file containing mosaic.")
+        parser.add_argument("center_ra",help="RA at the center of the extracted area",type=np.float)
+        parser.add_argument("center_dec",help="Dec at the center of the extracted area",type=np.float)
+        parser.add_argument("--channel",help="NIRCam channel the extracted data are meant to simulate (short, long)",default='short')
+        parser.add_argument("--outfile",help="Name of output fits file containing extracted image",default=None)
+        return parser
+
+if __name__ == '__main__':
+    usagestring = 'USAGE: crop_mosaic.py filename.fits 23.43 -21.2'
+
+    ex = Extraction()
+    parser = ex.add_options(usage = usagestring)
+    args = parser.parse_args(namespace=ex)
+    ex.extract()
+

--- a/obs_generator/scripts/rotations.py
+++ b/obs_generator/scripts/rotations.py
@@ -1,0 +1,167 @@
+'''A collection of basic routines for doing rotation calculations
+Changed to express quaternion as vector before scalar part(a,p,)'''
+from math import *
+import numpy as np
+
+def unit(ra, dec):
+    ''' Converts vector expressed in Euler angles to unit vector components.
+    ra and dec in degrees
+    Can be used for V2V3 after converting from arcsec to degrees)'''
+    
+    rar = radians(ra)
+    decr = radians(dec)
+    u = np.array([cos(rar)*cos(decr), sin(rar)*cos(decr), sin(decr)])
+    return u
+    
+def radec(u):
+    '''convert unit vector to Euler angles
+    u is an array or list of length 3'''
+    
+    if len(u) != 3:
+        print ('Not a vector')
+        return
+    norm = sqrt(u[0]**2 + u[1]**2 + u[2]**2) # Works for list or array
+    dec = degrees(asin(u[2]/norm))
+    ra = degrees(atan2(u[1], u[0])) # atan2 puts it in the correct quadrant
+    if ra < 0.0: ra += 360.0    # Astronomers prefer the range 0 to 360 degrees
+    return (ra, dec)
+
+def v2v3(u):
+    '''Convert unit vector to v2v3'''
+    if len(u) != 3:
+        print ('Not a vector')
+        return
+    norm = sqrt(u[0]**2 + u[1]**2 + u[2]**2) # Works for list or array
+    v2 = 3600*degrees(atan2(u[1], u[0])) # atan2 puts it in the correct quadrant
+    v3 = 3600*degrees(asin(u[2]/norm))
+    return (v2,v3)
+
+def rotate(axis,angle):
+    '''Fundamental rotation matrices.
+    Rotate by angle measured in degrees, about axis 1 2 or 3'''
+    if axis not in list(range(1,4)):
+        print ('Axis must be in range 1 to 3')
+        return
+    r = np.zeros((3,3))
+    ax0 = axis-1 #Allow for zero offset numbering
+    theta = radians(angle)
+    r[ax0,ax0] = 1.0
+    ax1 = (ax0+1) % 3
+    ax2 = (ax0+2) % 3
+    r[ax1, ax1] = cos(theta)
+    r[ax2, ax2] = cos(theta)
+    r[ax1, ax2] = -sin(theta)
+    r[ax2, ax1] = sin(theta)
+    return r
+    
+def rv(v2,v3):
+    '''Rotate from v2,v3 position to V1 axis'''
+    v2d = v2/3600.0 #convert from arcsec to degrees
+    v3d = v3/3600.0
+    mv2 = rotate(3,-v2d)
+    mv3 = rotate(2,v3d)
+    rv = np.dot(mv3,mv2)
+    return rv    
+    
+
+def slew(v2t, v3t, v2a, v3a):
+    ''' Calculate matrix which slews from target (v2t,v3t)
+    to aperture position (v2a, v3a)'''
+    v2td = v2t/3600.0
+    v3td = v3t/3600.0
+    v2ad = v2a/3600.0
+    v3ad = v3a/3600.0
+    r1 = rotate(3,-v2td)
+    r2 = rotate(2,v3td-v3ad)
+    r3 = rotate(3, v2ad)
+    # Combine r3 r2 r1
+    mv = np.dot(r2,r1)
+    mv = np.dot(r3,mv)
+    return mv
+
+def attitude(v2, v3, ra, dec, pa):
+    '''This will make a rotation matrix which rotates a unit vector representing a v2,v3 position
+    to a unit vector representing an RA, Dec pointing with an assigned position angle
+    Described in JWST-STScI-001550, SM-12, section 6.1'''
+    
+    # v2, v3 in arcsec, ra, dec and position angle in degrees
+    v2d = v2/3600.0
+    v3d = v3/3600.0
+    
+    # Get separate rotation matrices
+    mv2 = rotate(3, -v2d)
+    mv3 = rotate(2, v3d)
+    mra = rotate(3, ra)
+    mdec = rotate(2, -dec)
+    mpa = rotate(1, -pa)
+    
+    # Combine as mra*mdec*mpa*mv3*mv2
+    m = np.dot(mv3, mv2)
+    m = np.dot(mpa, m)
+    m = np.dot(mdec, m)
+    m = np.dot(mra, m)
+    
+    return m
+    
+def pointing(attitude, v2, v3):
+    '''Using the attitude matrix to calculate where any v2v3 position points on the sky'''
+    v2d = v2/3600.0
+    v3d = v3/3600.0
+    v = unit(v2d,v3d)
+    w = np.dot(attitude,v)
+    rd = radec(w)
+    return rd # tuple containing ra and dec
+    
+def getv2v3(attitude, ra, dec):
+    ''' Using the inverse of attitude matrix 
+    find v2,v3 position of any RA and DEC'''
+    urd = unit(ra, dec)
+    invAtt = np.linalg.inv(attitude)
+    uv = np.dot(invAtt,urd)
+    (v2,v3) = radec(uv)
+    if v2 > 180.0: v2 = v2-360.0
+    v2 = 3600.0*v2
+    v3 = 3600.0*v3
+    return (v2,v3)
+    
+def posangle(attitude, v2,v3):
+    ''' Using the attitude matrix find the V3 angle at arbitrary v2,v3
+    This is the angle measured from North to V3 in an anti-clockwise direction
+    i.e. North to East 
+    Formulae from JWST-STScI-001550, SM-12, section 6.2
+    Subtract 1 from each index in the text to allow for python zero indexing'''
+    
+    A = attitude  # Synonym to simplify typing
+    v2r = radians(v2/3600.0)
+    v3r = radians(v3/3600.0)
+    x = -(A[2,0]*cos(v2r) + A[2,1]*sin(v2r))*sin(v3r) + A[2,2]*cos(v3r)
+    y = (A[0,0]*A[1,2] - A[1,0]*A[0,2])*cos(v2r) + (A[0,1]*A[1,2] - A[1,1]*A[0,2])*sin(v2r)
+    pa = degrees(atan2(y,x))
+    return pa
+
+def rodrigues(attitude):
+    '''Interpret rotation matrix as a single rotation by angle phi around unit length axis
+    Return axis, angle and matching quaternion'''
+    
+    A = attitude # Synonym for clarity and to save typing
+    cos_phi = 0.5*(A[0,0] + A[1,1] + A[2,2] - 1.0)
+    phi = acos(cos_phi)
+    axis = np.array([A[2,1]-A[1,2], A[0,2]-A[2,0], A[1,0]-A[0,1]])/(2.0*sin(phi))
+    # Make corresponding quaternion
+    q = np.hstack(( axis*sin(phi/2.0), [cos(phi/2.0)]))
+    phi = degrees(phi)
+    return (axis,phi,q)
+
+def cross(a,b):
+    """cross product of two vectors"""
+    c = np.array([a[1]*b[2]-a[2]*b[1], a[2]*b[0]-a[0]*b[2], a[0]*b[1]-a[1]*b[0]])
+    return c
+        
+def axial(ax, phi, u):
+    ''' Apply direct rotation to a vector using Rodrigues' formula
+    ax is unit axis vector  phi is rotation angle in degrees
+    u is initial vector'''
+    rphi = radians(phi)
+    v = u*cos(rphi) + cross(ax,u)*sin(rphi) + ax*np.dot(ax,u)*(1-cos(rphi))
+    return v
+


### PR DESCRIPTION
The new scripts allow the cropping and blotting of distortion-free mosaic images onto NIRCam detectors. Also added apt_inputs.py, which converts exposure information in xml and pointings files from APT into an (ugly) list. This is used to get RA and Dec values for each detector for a given pointing. It is also the first step used in the yaml_generator, which will produce yaml data simulator input files from an APT file.
